### PR TITLE
Added support for loading standard menu on OS X platform

### DIFF
--- a/source/app/app.js
+++ b/source/app/app.js
@@ -3,6 +3,7 @@
 var electron        = require('electron'),
     app             = electron.app,
     BrowserWindow   = electron.BrowserWindow,
+    Menu            = electron.Menu,
     ipc             = electron.ipcMain,
     path            = require('path'),
     EventsManager   = require('./events.js')(),
@@ -46,4 +47,165 @@ app.on('window-all-closed', function() {
 app.on('ready', function() {
    // Show intro
    windowManager.buildWindowOfType("intro");
+
+   // Show standard menu if on OS X
+   if (process.platform == 'darwin') {
+     var template = [
+       {
+         label: name,
+         submenu: [
+           {
+             label: 'About Buttercup',
+             role: 'about'
+           },
+           {
+             type: 'separator'
+           },
+           {
+             label: 'Services',
+             role: 'services',
+             submenu: []
+           },
+           {
+             type: 'separator'
+           },
+           {
+             label: 'Hide ' + name,
+             accelerator: 'Command+H',
+             role: 'hide'
+           },
+           {
+             label: 'Hide Others',
+             accelerator: 'Command+Alt+H',
+             role: 'hideothers'
+           },
+           {
+             label: 'Show All',
+             role: 'unhide'
+           },
+           {
+             type: 'separator'
+           },
+           {
+             label: 'Quit',
+             accelerator: 'Command+Q',
+             click: function() { app.quit(); }
+           },
+         ]
+       },
+       {
+         label: 'Edit',
+         submenu: [
+           {
+             label: 'Undo',
+             accelerator: 'CmdOrCtrl+Z',
+             role: 'undo'
+           },
+           {
+             label: 'Redo',
+             accelerator: 'Shift+CmdOrCtrl+Z',
+             role: 'redo'
+           },
+           {
+             type: 'separator'
+           },
+           {
+             label: 'Cut',
+             accelerator: 'CmdOrCtrl+X',
+             role: 'cut'
+           },
+           {
+             label: 'Copy',
+             accelerator: 'CmdOrCtrl+C',
+             role: 'copy'
+           },
+           {
+             label: 'Paste',
+             accelerator: 'CmdOrCtrl+V',
+             role: 'paste'
+           },
+           {
+             label: 'Select All',
+             accelerator: 'CmdOrCtrl+A',
+             role: 'selectall'
+           },
+         ]
+       },
+       {
+         label: 'View',
+         submenu: [
+           {
+             label: 'Reload',
+             accelerator: 'CmdOrCtrl+R',
+             click: function(item, focusedWindow) {
+               if (focusedWindow)
+                 focusedWindow.reload();
+             }
+           },
+           {
+             label: 'Toggle Full Screen',
+             accelerator: (function() {
+               if (process.platform == 'darwin')
+                 return 'Ctrl+Command+F';
+               else
+                 return 'F11';
+             })(),
+             click: function(item, focusedWindow) {
+               if (focusedWindow)
+                 focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+             }
+           },
+           {
+             label: 'Toggle Developer Tools',
+             accelerator: (function() {
+               if (process.platform == 'darwin')
+                 return 'Alt+Command+I';
+               else
+                 return 'Ctrl+Shift+I';
+             })(),
+             click: function(item, focusedWindow) {
+               if (focusedWindow)
+                 focusedWindow.toggleDevTools();
+             }
+           },
+         ]
+       },
+       {
+         label: 'Window',
+         role: 'window',
+         submenu: [
+           {
+             label: 'Minimize',
+             accelerator: 'CmdOrCtrl+M',
+             role: 'minimize'
+           },
+           {
+             label: 'Close',
+             accelerator: 'CmdOrCtrl+W',
+             role: 'close'
+           },
+           {
+             type: 'separator'
+           },
+           {
+             label: 'Bring All to Front',
+             role: 'front'
+           }
+         ]
+       },
+       {
+         label: 'Help',
+         role: 'help',
+         submenu: [
+           {
+             label: 'Learn More',
+             click: function() { require('electron').shell.openExternal('http://buttercup.pw') }
+           },
+         ]
+       },
+     ];
+   }
+
+   var menu = Menu.buildFromTemplate(template);
+   Menu.setApplicationMenu(menu);
 });

--- a/source/app/app.js
+++ b/source/app/app.js
@@ -52,7 +52,7 @@ app.on('ready', function() {
    if (process.platform == 'darwin') {
      var template = [
        {
-         label: name,
+         label: 'Buttercup',
          submenu: [
            {
              label: 'About Buttercup',
@@ -70,7 +70,7 @@ app.on('ready', function() {
              type: 'separator'
            },
            {
-             label: 'Hide ' + name,
+             label: 'Hide Buttercup',
              accelerator: 'Command+H',
              role: 'hide'
            },


### PR DESCRIPTION
I thought I'd have a go at a simple implementation to cover https://github.com/buttercup-pw/buttercup/issues/45.

This adds the basics for OS X menus, which allows OS X users to copy and paste on fields and manage the window.