### PR TITLE
separate the CMD+Q command from the user closing windows, resolves #29

### DIFF
--- a/source/app/app.js
+++ b/source/app/app.js
@@ -38,9 +38,12 @@ windowManager.setBuildProcedure("intro", function openIntroScreen() {
     return introScreen;
 });
 
-// Quit when all windows are closed.
+// When user closes all windows
 app.on('window-all-closed', function() {
-
+    // Reopen the Intro window
+    if (windowManager.getCountOfType("archive") <= 0) {
+        windowManager.buildWindowOfType("intro");
+    }
 });
 
 app.on('ready', function() {

--- a/source/app/events.js
+++ b/source/app/events.js
@@ -45,12 +45,9 @@
             archiveWindow.show();
             //archiveWindow.webContents.openDevTools();
 
-            // Emitted when the window is closed.
-            archiveWindow.on('closed', function() {
+            // Emitted when the window will close
+            archiveWindow.on('close', function() {
                 windowManager.deregister(archiveWindow);
-                if (windowManager.getCountOfType("archive") <= 0) {
-                    windowManager.buildWindowOfType("intro");
-                }
             });
 
             // Close intro screen


### PR DESCRIPTION
The `window-all-closed` event will handle the reopening of the Intro window, instead of the Archive windo itself so we can have a gracefull shutdown when user hits CMD+Q(or clicks Quit from the menu).