### PR TITLE
Add confirmation for password generation

### DIFF
--- a/source/resources/js/app/tools/dialog.js
+++ b/source/resources/js/app/tools/dialog.js
@@ -19,7 +19,7 @@ export function confirmDialog(message, detail, button, callback) {
    		confirmButtonColor: "#DD6B55",
    		confirmButtonText: button,
    		cancelButtonText: "Cancel"
-   	}, (confirm) => {
+   	}, (confirm) =>	 {
         callback(confirm);
     });
 }

--- a/source/resources/js/app/tools/dialog.js
+++ b/source/resources/js/app/tools/dialog.js
@@ -9,16 +9,17 @@ import swal from 'sweetalert';
  * @param  {string} detail
  * @return {boolean}
  */
-export function confirmDialog(message, detail, callback) {
+export function confirmDialog(message, detail, button, callback) {
+	button = button || "Delete";
     swal({
     	title: message,
    		text: detail,
    		type: "warning",
    		showCancelButton: true,
    		confirmButtonColor: "#DD6B55",
-   		confirmButtonText: "Delete",
+   		confirmButtonText: button,
    		cancelButtonText: "Cancel"
    	}, (confirm) => {
-        callback(confirm)
+        callback(confirm);
     });
 }

--- a/source/resources/js/app/tools/generate.js
+++ b/source/resources/js/app/tools/generate.js
@@ -38,7 +38,6 @@ export function generatePassword(length) {
     const randomLength = length || Math.floor(Math.random() * (maxLength - minLength)) + minLength;
     while (!isStrongEnough(password)) {
         password = passgen(randomLength, false, /[\w\d\?\-]/);
-        console.log(password);
     }
     return password;
 }

--- a/source/resources/js/app/tools/generate.js
+++ b/source/resources/js/app/tools/generate.js
@@ -38,6 +38,7 @@ export function generatePassword(length) {
     const randomLength = length || Math.floor(Math.random() * (maxLength - minLength)) + minLength;
     while (!isStrongEnough(password)) {
         password = passgen(randomLength, false, /[\w\d\?\-]/);
+        console.log(password);
     }
     return password;
 }

--- a/source/resources/js/app/views/entry.js
+++ b/source/resources/js/app/views/entry.js
@@ -178,7 +178,7 @@ export default Backbone.View.extend({
     removeEntry: function () {
         confirmDialog(
             `Delete ${this.model.get("title")}?`,
-            `Are you sure you want to delete this entry? This cannot be undone.`,
+            `Are you sure you want to delete this entry?`,
             "Delete",
             (confirm) => {
                 if (confirm === true) {

--- a/source/resources/js/app/views/entry.js
+++ b/source/resources/js/app/views/entry.js
@@ -88,8 +88,23 @@ export default Backbone.View.extend({
         e.preventDefault();
         var $field = this.$('input[name=password]'),
             type = $field.attr('type');
-
-        $field.val(generatePassword());
+        
+        if(!$field.val()){
+            $field.first().val(generatePassword());
+        }
+        else {
+            confirmDialog(
+                "Generate a new password?",
+                "This would replace your current password.",
+                "Generate",
+                (confirm) => {
+                    if (confirm === true) {
+                        console.log("confirmed");
+                        $field.first().val(generatePassword());
+                    }
+                }
+            );            
+        }  
         $field.keyup();
     },
 
@@ -164,7 +179,8 @@ export default Backbone.View.extend({
     removeEntry: function () {
         confirmDialog(
             `Delete ${this.model.get("title")}?`,
-            `Are you sure you want to delete this entry?`,
+            `Are you sure you want to delete this entry? This cannot be undone.`,
+            "Delete",
             (confirm) => {
                 if (confirm === true) {
                     this.model.destroy({
@@ -176,6 +192,6 @@ export default Backbone.View.extend({
                     });
                 }
             }
-        );
+        );  
     }
 });

--- a/source/resources/js/app/views/entry.js
+++ b/source/resources/js/app/views/entry.js
@@ -99,7 +99,6 @@ export default Backbone.View.extend({
                 "Generate",
                 (confirm) => {
                     if (confirm === true) {
-                        console.log("confirmed");
                         $field.first().val(generatePassword());
                     }
                 }

--- a/source/resources/js/app/views/sidebar.js
+++ b/source/resources/js/app/views/sidebar.js
@@ -111,6 +111,7 @@ const SidebarGroupItemView = Backbone.View.extend({
         confirmDialog(
             `Delete ${this.model.get("title")}?`,
             `Are you sure you want to delete this group? This cannot be undone.`,
+            "Delete",
             (result) => {
                 if (result === true) {
                     this.model.destroy();


### PR DESCRIPTION
To avoid accidentally erasing passwords from generating a new password, a confirmation dialog box new pops up if the password box is already populating when generating a new password.