### PR TITLE
fix: hide arrow if group has no children

### DIFF
--- a/src/renderer/styles/tree-view.global.scss
+++ b/src/renderer/styles/tree-view.global.scss
@@ -114,6 +114,12 @@ $treePrefixCls: 'rc-tree';
         }
       }
     }
+
+    &.is-empty {
+      .#{$treePrefixCls}-switcher {
+        opacity: 0;
+      }
+    }
   }
 
   &-title {


### PR DESCRIPTION
Fixes #118 