### PR TITLE
Change minimum length of generated passwords to 10 chars

### DIFF
--- a/src/renderer/components/generator.js
+++ b/src/renderer/components/generator.js
@@ -103,7 +103,7 @@ class Generator extends Component {
             <input
               type="range"
               value={this.state.length}
-              min="20"
+              min="10"
               max="50"
               onChange={e => this.changeLength(e)}
               />


### PR DESCRIPTION
Updating the length so it can be a minimum of 10 characters makes for some faster-typed passwords:

![image](https://cloud.githubusercontent.com/assets/3869469/22160123/af1e14e6-df4c-11e6-9447-5334dc66f005.png)

This is also inline with [NIST's recommended minimum length](https://nakedsecurity.sophos.com/2016/08/18/nists-new-password-rules-what-you-need-to-know/) of 8 characters.

The generated passwords are still quite secure, and can be more practical than the 20 char ones. This update just allows for more flexibility.