### PR TITLE
Move Groups to Root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-os:
-  - osx
+#os:
+#  - osx
 
 language: node_js
 
@@ -7,3 +7,10 @@ node_js:
   - 7
 
 script: ./script/travis.sh
+
+before_install:
+  - rm yarn.lock
+
+branches:
+  only:
+  - master

--- a/app/index.html
+++ b/app/index.html
@@ -17,11 +17,9 @@
   <body>
     <div id="root"></div>
     <script>
-      (function() {
-        const script = document.createElement('script');
-        script.src = (process.env.HOT) ? 'http://localhost:3000/app/bundle.js' : './bundle.js';
-        document.write(script.outerHTML);
-      }());
+      const script = document.createElement('script');
+      script.src = (process.env.HOT) ? 'http://localhost:3000/app/bundle.js' : './bundle.js';
+      document.head.appendChild(script);
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "devDependencies": {
     "@types/electron": "^1.4.29",
     "@types/node": "^6.0.45",
+    "@types/rc-tree": "^1.4.2",
     "@types/react": "^0.14.41",
     "@types/redux": "^3.6.31",
     "ava": "^0.17.0",
@@ -151,7 +152,7 @@
     "ms": "^0.7.2",
     "node-sass": "^3.10.1",
     "raw-loader": "^0.5.1",
-    "rc-tree": "^1.3.9",
+    "rc-tree": "^1.4.5",
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "devDependencies": {
     "@types/electron": "^1.4.29",
     "@types/node": "^6.0.45",
-    "@types/rc-tree": "^1.4.2",
     "@types/react": "^0.14.41",
     "@types/redux": "^3.6.31",
     "ava": "^0.17.0",
@@ -152,7 +151,7 @@
     "ms": "^0.7.2",
     "node-sass": "^3.10.1",
     "raw-loader": "^0.5.1",
-    "rc-tree": "^1.4.5",
+    "rc-tree": "^1.3.9",
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",

--- a/script/travis.sh
+++ b/script/travis.sh
@@ -9,5 +9,5 @@ fi
 node --version
 npm --version
 
-npm run build && npm run release:mac
+npm run build
 npm test

--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -31,12 +31,12 @@ class TreeView extends Component {
         { type: 'separator' },
         {
           label: 'Move to Root',
-          click: () => this.props.onDrop(groupId, null)
+          click: () => this.props.onMoveGroup(groupId, null)
         },
         {
           label: 'Move to Group',
           submenu: createMenuFromGroups(groups, groupId, selectedGroupId => {
-            this.props.onDrop(groupId, selectedGroupId);
+            this.props.onMoveGroup(groupId, selectedGroupId);
           }, false)
         },
         { type: 'separator' },
@@ -69,7 +69,7 @@ class TreeView extends Component {
   handleDrop = info => {
     const dropKey = info.node.props.eventKey;
     const dragKey = info.dragNode.props.eventKey;
-    this.props.onDrop(dragKey, dropKey);
+    this.props.onMoveGroup(dragKey, dropKey);
   }
 
   handleSelect = ([selectedGroupId]) => {
@@ -147,7 +147,7 @@ TreeView.propTypes = {
   onAddClick: PropTypes.func,
   onGroupSelect: PropTypes.func,
   onEmptyTrash: PropTypes.func,
-  onDrop: PropTypes.func,
+  onMoveGroup: PropTypes.func,
   onExpand: PropTypes.func
 };
 

--- a/src/renderer/components/tree-view/index.js
+++ b/src/renderer/components/tree-view/index.js
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import Tree, { TreeNode } from 'rc-tree';
 import PlusIcon from 'react-icons/lib/md/add';
 import { Button } from 'buttercup-ui';
-import { showContextMenu } from '../../system/menu';
+import { showContextMenu, createMenuFromGroups } from '../../system/menu';
 import { isOSX } from '../../system/utils';
 import '../../styles/tree-view.global';
 import styles from '../../styles/tree-view';
@@ -12,8 +12,8 @@ import Column from '../column';
 import TreeLabel from './tree-label';
 
 class TreeView extends Component {
-  handleRightClick = info => {
-    const { id: groupId, isTrash } = info;
+  handleRightClick = (node, groups) => {
+    const { id: groupId, isTrash } = node;
 
     if (isTrash) {
       showContextMenu([
@@ -28,6 +28,18 @@ class TreeView extends Component {
           label: 'Add Group', 
           click: () => this.handleAddClick(null, groupId)
         },
+        { type: 'separator' },
+        {
+          label: 'Move to Root',
+          click: () => this.props.onDrop(groupId, null)
+        },
+        {
+          label: 'Move to Group',
+          submenu: createMenuFromGroups(groups, groupId, selectedGroupId => {
+            this.props.onDrop(groupId, selectedGroupId);
+          }, false)
+        },
+        { type: 'separator' },
         {
           label: 'Delete',
           click: () => this.handleRemoveClick(null, groupId)
@@ -67,6 +79,7 @@ class TreeView extends Component {
   }
 
   render() {
+    const { groups } = this.props;
     const loop = children => {
       if (!children) {
         return null;
@@ -86,7 +99,7 @@ class TreeView extends Component {
               <TreeLabel
                 {...node}
                 {...this.props}
-                onRightClick={() => this.handleRightClick(node)}
+                onRightClick={() => this.handleRightClick(node, groups)}
                 onAddClick={this.handleAddClick}
                 onRemoveClick={this.handleRemoveClick}
                 />
@@ -119,7 +132,7 @@ class TreeView extends Component {
           onExpand={this.handleExpand}
           onDrop={this.handleDrop}
           >
-          {loop(this.props.groups)}
+          {loop(groups)}
         </Tree>
       </Column>
     );

--- a/src/renderer/containers/tree-view.js
+++ b/src/renderer/containers/tree-view.js
@@ -23,7 +23,7 @@ export default connect(
     onRemoveClick: removeGroup,
     onSaveClick: saveGroupTitle,
     onEmptyTrash: emptyTrash,
-    onDrop: moveGroupToParent,
+    onMoveGroup: moveGroupToParent,
     onGroupSelect: loadGroup,
     onExpand: setExpandedKeys
   }

--- a/src/renderer/styles/tree-view.global.scss
+++ b/src/renderer/styles/tree-view.global.scss
@@ -1,3 +1,4 @@
+@import 'variables';
 $treePrefixCls: 'rc-tree';
 
 .#{$treePrefixCls} {
@@ -27,13 +28,13 @@ $treePrefixCls: 'rc-tree';
 
     &.drag-over-gap-top {
       > .draggable {
-        border-top: 2px blue solid;
+        border-top: 5px $brand-primary solid;
       }
     }
 
     &.drag-over-gap-bottom {
       > .draggable {
-        border-bottom: 2px blue solid;
+        border-bottom: 5px $brand-primary solid;
       }
     }
 

--- a/src/renderer/styles/workspace.global.scss
+++ b/src/renderer/styles/workspace.global.scss
@@ -21,6 +21,9 @@
 
 html {
   height: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 body {

--- a/src/renderer/system/buttercup/groups.js
+++ b/src/renderer/system/buttercup/groups.js
@@ -92,7 +92,7 @@ export function saveGroup(groupId, title) {
 export function moveGroup(groupId, parentId) {
   const arch = getArchive();
   const group = arch.findGroupByID(groupId);
-  const parent = arch.findGroupByID(parentId);
+  const parent = parentId ? arch.findGroupByID(parentId) : arch;
 
   if (!group || !parent) {
     throw new Error('Group has not been found.');

--- a/src/renderer/system/buttercup/groups.js
+++ b/src/renderer/system/buttercup/groups.js
@@ -89,10 +89,10 @@ export function saveGroup(groupId, title) {
  * @param {string} groupId
  * @param {string} parentId
  */
-export function moveGroup(groupId, parentId, dropToGap) {
+export function moveGroup(groupId, parentId, dropToGap = false) {
   const arch = getArchive();
   const group = arch.findGroupByID(groupId);
-  const parent = arch.findGroupByID(parentId);
+  const parent = parentId ? arch.findGroupByID(parentId) : arch;
 
   if (!group || !parent) {
     throw new Error('Group has not been found.');
@@ -117,9 +117,13 @@ export function emptyTrash() {
   save();
 }
 
+/**
+ * Check if a Group is a Root Group
+ * @param {Buttercup.Group} group Group Object
+ */
 function isRootGroup(group) {
   const rootGroups = getArchive().getGroups();
-  for (let i = 0; i < rootGroups.length; ++i) {
+  for (let i = 0; i < rootGroups.length; i += 1) {
     if (group.getID() === rootGroups[i].getID()) {
       return true;
     }

--- a/src/renderer/system/menu.js
+++ b/src/renderer/system/menu.js
@@ -1,15 +1,10 @@
 import { remote } from 'electron';
 
-const { Menu, MenuItem } = remote;
+const { Menu } = remote;
 const currentWindow = remote.getCurrentWindow();
 
 export function createMenu(items = []) {
-  const menu = new Menu();
-  const menuItems = items.map(item => new MenuItem(item));
-  menuItems.forEach(item => {
-    menu.append(item);
-  });
-  return menu;
+  return Menu.buildFromTemplate(items);
 }
 
 export function showContextMenu(items = []) {
@@ -17,26 +12,35 @@ export function showContextMenu(items = []) {
   menu.popup(currentWindow);
 }
 
-export function createMenuFromGroups(groups = [], currentGroup, fn) {
-  return createMenu(groups.filter(group => !group.isTrash).map(group => {
-    if (group.type) {
-      return group;
-    }
-    return {
-      label: group.title,
-      enabled: (group.id !== currentGroup || group.groups.length > 0),
-      click: () => fn(group.id),
-      submenu: group.groups.length > 0 ?
-        createMenuFromGroups(
-          [{
-            ...group,
-            title: `Move to ${group.title}`,
-            groups: []
-          }, {
-            type: 'separator'
-          }]
-          .concat(group.groups), currentGroup, fn) :
-        null
-    };
-  }));
+export function createMenuFromGroups(groups = [], currentGroup, fn, allowMoveToSelf = true) {
+  return createMenu(
+    groups
+      .filter(group => {
+        if (group.id === currentGroup && allowMoveToSelf === false) {
+          return false;
+        }
+        return !group.isTrash;
+      })
+      .map(group => {
+        if (group.type) {
+          return group;
+        }
+        return {
+          label: group.title,
+          enabled: (group.id !== currentGroup || group.groups.length > 0),
+          click: () => fn(group.id),
+          submenu: group.groups.length > 0 ?
+            createMenuFromGroups(
+              [{
+                ...group,
+                title: `Move to ${group.title}`,
+                groups: []
+              }, {
+                type: 'separator'
+              }]
+              .concat(group.groups), currentGroup, fn, allowMoveToSelf) :
+            null
+        };
+      })
+  );
 }

--- a/test/app.js
+++ b/test/app.js
@@ -4,7 +4,8 @@ import { Application } from 'spectron';
 
 test.beforeEach(async t => {
   t.context.app = new Application({
-    path: path.join(__dirname, '../release/mac/Buttercup.app/Contents/MacOS/Buttercup')
+    path: require('electron'),
+    args: [path.join(__dirname, '../app')]
   });
 
   await t.context.app.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,13 @@
   version "6.0.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.62.tgz#85222c077b54f25b57417bb708b9f877bda37f89"
 
-"@types/react@^0.14.41":
+"@types/rc-tree@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/rc-tree/-/rc-tree-1.4.2.tgz#909ebe4a841928d2baf1079ffa91477b4e53e427"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^0.14.41":
   version "0.14.57"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-0.14.57.tgz#1878a8654fafdd1d381b8457292b6433498c5b62"
 
@@ -92,6 +98,12 @@ acorn@^2.1.0, acorn@^2.4.0:
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
+add-dom-event-listener@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
+  dependencies:
+    object-assign "4.x"
 
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
@@ -5080,7 +5092,7 @@ lodash.kebabcase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
-lodash.keys@^3.0.0:
+lodash.keys@^3.0.0, lodash.keys@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
   dependencies:
@@ -6585,13 +6597,21 @@ rc-animate@2.x:
   dependencies:
     css-animation "^1.3.0"
 
-rc-tree@^1.3.9:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.4.2.tgz#e1ef4a14a24d3bbc57c1273873a3a86db6fb94df"
+rc-tree@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.4.5.tgz#5712ccabff0eec5073fbd5b717f4c930d003ce7b"
   dependencies:
     classnames "2.x"
     object-assign "4.x"
     rc-animate "2.x"
+    rc-util "^4.0.2"
+
+rc-util@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.2.tgz#5804f8b141a13c8c14d7c265a7d21d298195af46"
+  dependencies:
+    add-dom-event-listener "1.x"
+    shallowequal "^0.2.2"
 
 rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@~1.1.6:
   version "1.1.6"
@@ -7243,6 +7263,12 @@ sha.js@^2.3.6:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  dependencies:
+    lodash.keys "^3.1.2"
 
 shelljs@^0.7.0, shelljs@^0.7.5:
   version "0.7.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,13 +36,7 @@
   version "6.0.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.62.tgz#85222c077b54f25b57417bb708b9f877bda37f89"
 
-"@types/rc-tree@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/rc-tree/-/rc-tree-1.4.2.tgz#909ebe4a841928d2baf1079ffa91477b4e53e427"
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@^0.14.41":
+"@types/react@^0.14.41":
   version "0.14.57"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-0.14.57.tgz#1878a8654fafdd1d381b8457292b6433498c5b62"
 
@@ -98,12 +92,6 @@ acorn@^2.1.0, acorn@^2.4.0:
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-add-dom-event-listener@1.x:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
-  dependencies:
-    object-assign "4.x"
 
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
@@ -5092,7 +5080,7 @@ lodash.kebabcase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
-lodash.keys@^3.0.0, lodash.keys@^3.1.2:
+lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
   dependencies:
@@ -6597,21 +6585,13 @@ rc-animate@2.x:
   dependencies:
     css-animation "^1.3.0"
 
-rc-tree@^1.4.5:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.4.5.tgz#5712ccabff0eec5073fbd5b717f4c930d003ce7b"
+rc-tree@^1.3.9:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/rc-tree/-/rc-tree-1.4.2.tgz#e1ef4a14a24d3bbc57c1273873a3a86db6fb94df"
   dependencies:
     classnames "2.x"
     object-assign "4.x"
     rc-animate "2.x"
-    rc-util "^4.0.2"
-
-rc-util@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.0.2.tgz#5804f8b141a13c8c14d7c265a7d21d298195af46"
-  dependencies:
-    add-dom-event-listener "1.x"
-    shallowequal "^0.2.2"
 
 rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@~1.1.6:
   version "1.1.6"
@@ -7263,12 +7243,6 @@ sha.js@^2.3.6:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
-
-shallowequal@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
-  dependencies:
-    lodash.keys "^3.1.2"
 
 shelljs@^0.7.0, shelljs@^0.7.5:
   version "0.7.6"


### PR DESCRIPTION
This PR adds:

+ moving groups to other groups by right clicking on them
+ moving groups to root by dragging to gaps between groups or by right clicking
+ font smoothing in the UI

Fixes #147 
