### PR TITLE
Fix Search icon on Windows

### DIFF
--- a/src/renderer/components/archive/search-field.js
+++ b/src/renderer/components/archive/search-field.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import SearchIcon from 'react-icons/lib/md/search';
 import styles from '../../styles/search-field';
 
 class SearchField extends Component {
@@ -41,6 +42,9 @@ class SearchField extends Component {
             this.textInput = input;
           }}
           />
+        <span className={styles.icon}>
+          <SearchIcon/>
+        </span>
         {this.state.value !== '' && <span className={styles.clear} onClick={() => this.handleClearClick()}></span>}
       </div>
     );

--- a/src/renderer/styles/search-field.scss
+++ b/src/renderer/styles/search-field.scss
@@ -3,16 +3,13 @@
 .wrapper {
   position: relative;
   flex: 1;
+}
 
-  &:before {
-    display: block;
-    content: "⚲";
-    position: absolute;
-    transform: rotate(-45deg);
-    top: 2px;
-    left: 4px;
-    opacity: .5;
-  }
+.icon {
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  color: rgba(255,255,255,.5);
 }
 
 .field {


### PR DESCRIPTION
Search icon was using a unicode string which was not available on Windows.
Fixes #165 